### PR TITLE
Bugfix: Restore King Movement

### DIFF
--- a/src/game/Rules.js
+++ b/src/game/Rules.js
@@ -84,6 +84,7 @@ export default class Rules {
                 });
                 break;
 
+            case PieceType.KING:
                 // Normal moves
                 const kingMoves = [
                     [-1, -1], [-1, 0], [-1, 1],


### PR DESCRIPTION
Fixed a regression where the King move logic was unreachable due to a missing case label.